### PR TITLE
Fix memory leak: cache arrays in BEAGLE hot paths

### DIFF
--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -15,17 +15,26 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	
 	private MutableAlignment alignment;
 	private boolean alignmentNeedsUpdate;
-	
+	private int[] cachedOperations;
+	private int[] cachedStates;
+	private double[] cachedPartials;
+
 	@Override
 	public void initAndValidate() {
 		if (!(dataInput.get() instanceof MutableAlignment)) {
 			throw new IllegalArgumentException("Expected MutableAlignment as data, not " + dataInput.get().getClass().getName());
 		}
 		alignment = (MutableAlignment) dataInput.get();
-		
+
 		super.initAndValidate();
-		
+
 		alignmentNeedsUpdate = false;
+
+		int patternCount = alignment.getPatternCount();
+		int stateCount = alignment.getDataType().getStateCount();
+		cachedStates = new int[patternCount];
+		cachedPartials = new double[patternCount * stateCount];
+		cachedOperations = new int[treeInput.get().getNodeCount() * Beagle.OPERATION_TUPLE_SIZE];
 	}
 		
 	@Override
@@ -66,38 +75,34 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
             int taxonIndex = alignment.getTaxonIndex(node.getID());
 
             if (m_useAmbiguities.get()) {
-	            double[] partials = new double[patternCount * stateCount];
-	            
 	            int k = 0;
-	            for (int patternIndex_ = 0; patternIndex_ < patternCount; patternIndex_++) {                
+	            for (int patternIndex_ = 0; patternIndex_ < patternCount; patternIndex_++) {
 	                double[] tipLikelihoods = alignment.getTipLikelihoods(taxonIndex, patternIndex_);
 	                if (tipLikelihoods != null) {
 	                	for (int state = 0; state < stateCount; state++) {
-	                		partials[k++] = tipLikelihoods[state];
+	                		cachedPartials[k++] = tipLikelihoods[state];
 	                	}
 	                } else {
 	                	int statex = alignment.getPattern(taxonIndex, patternIndex_);
 		                boolean[] stateSet = alignment.getStateSet(statex);
 		                for (int state = 0; state < stateCount; state++) {
-		                	 partials[k++] = (stateSet[state] ? 1.0 : 0.0);                
+		                	 cachedPartials[k++] = (stateSet[state] ? 1.0 : 0.0);
 		                }
 	                }
 	            }
-	            beagle.setPartials(nodeNr, partials);
+	            beagle.setPartials(nodeNr, cachedPartials);
 	            
             } else {
-            	
-                int[] states = new int[patternCount];
                 DataType dataType = alignment.getDataType();
                 for (int i = 0; i < patternCount; i++) {
                     int code = alignment.getPattern(taxonIndex, i);
                     int[] statesForCode = dataType.getStatesForCode(code);
                     if (statesForCode.length==1)
-                        states[i] = statesForCode[0];
+                        cachedStates[i] = statesForCode[0];
                     else
-                        states[i] = code; // Causes ambiguous states to be ignored.
+                        cachedStates[i] = code; // Causes ambiguous states to be ignored.
                 }
-                beagle.setTipStates(nodeNr, states);
+                beagle.setTipStates(nodeNr, cachedStates);
                 node.makeDirty(Tree.IS_DIRTY);
             }
         }
@@ -108,22 +113,21 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	 * to states encoded in sites
 	 */
 	public double [] getLogProbsForStateSequence(int nodeNr, int [] sites) {
-		// update data for node 
+		// update data for node
 		int patternCount = sites.length;
         if (m_useAmbiguities.get()) {
         	throw new IllegalArgumentException("should not use getLogProbsForSequence but getLogProbsForPartialsSequence instead");
         }
-        int[] states = new int[patternCount];
         DataType dataType = alignment.getDataType();
         for (int i = 0; i < patternCount; i++) {
             int code = sites[i];
             int[] statesForCode = dataType.getStatesForCode(code);
             if (statesForCode.length==1)
-                states[i] = statesForCode[0];
+                cachedStates[i] = statesForCode[0];
             else
-                states[i] = code; // Causes ambiguous states to be ignored.
+                cachedStates[i] = code; // Causes ambiguous states to be ignored.
         }
-        beagle.setTipStates(nodeNr, states);
+        beagle.setTipStates(nodeNr, cachedStates);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
@@ -146,7 +150,7 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 
         Node node = treeInput.get().getNode(nodeNr);
         int operationCount = 0;
-        final int[] operations = new int[treeInput.get().getNodeCount() *  Beagle.OPERATION_TUPLE_SIZE];
+        final int[] operations = cachedOperations;
         do {
         	node = node.getParent();
         	nodeNr = node.getNr();

--- a/src/mutablealignment/BeagleTreeLikelihood.java
+++ b/src/mutablealignment/BeagleTreeLikelihood.java
@@ -1151,7 +1151,7 @@ public class BeagleTreeLikelihood extends TreeLikelihood {
      * the BEAGLE library instance
      */
     protected Beagle beagle;
-    
+
     public Beagle getBeagle() {return beagle;}
 
     /**

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -16,20 +16,27 @@ public class MATreeLikelihood extends TreeLikelihood {
 	
 	private MutableAlignment alignment;
 	private boolean alignmentNeedsUpdate;
-	
+	private int[] cachedStates;
+	private double[] cachedPartials;
+
 	@Override
 	public void initAndValidate() {
 		if (!(dataInput.get() instanceof MutableAlignment)) {
 			throw new IllegalArgumentException("Expected MutableAlignment as data, not " + dataInput.get().getClass().getName());
 		}
 		alignment = (MutableAlignment) dataInput.get();
-		
+
 		boolean useJava = System.getProperty("java.only") == null ? false : Boolean.valueOf(System.getProperty("java.only"));
 		System.setProperty("java.only", "true");
 		super.initAndValidate();
 		System.setProperty("java.only", useJava + "");
-		
+
 		alignmentNeedsUpdate = false;
+
+		int patternCount = alignment.getPatternCount();
+		int stateCount = alignment.getDataType().getStateCount();
+		cachedStates = new int[patternCount];
+		cachedPartials = new double[patternCount * stateCount];
 	}
 		
 	@Override
@@ -70,38 +77,34 @@ public class MATreeLikelihood extends TreeLikelihood {
             int taxonIndex = alignment.getTaxonIndex(node.getID());
 
             if (m_useAmbiguities.get()) {
-	            double[] partials = new double[patternCount * stateCount];
-	            
 	            int k = 0;
-	            for (int patternIndex_ = 0; patternIndex_ < patternCount; patternIndex_++) {                
+	            for (int patternIndex_ = 0; patternIndex_ < patternCount; patternIndex_++) {
 	                double[] tipLikelihoods = alignment.getTipLikelihoods(taxonIndex, patternIndex_);
 	                if (tipLikelihoods != null) {
 	                	for (int state = 0; state < stateCount; state++) {
-	                		partials[k++] = tipLikelihoods[state];
+	                		cachedPartials[k++] = tipLikelihoods[state];
 	                	}
 	                } else {
 	                	int statex = alignment.getPattern(taxonIndex, patternIndex_);
 		                boolean[] stateSet = alignment.getStateSet(statex);
 		                for (int state = 0; state < stateCount; state++) {
-		                	 partials[k++] = (stateSet[state] ? 1.0 : 0.0);                
+		                	 cachedPartials[k++] = (stateSet[state] ? 1.0 : 0.0);
 		                }
 	                }
 	            }
-	            likelihoodCore.setNodePartials(nodeNr, partials);
+	            likelihoodCore.setNodePartials(nodeNr, cachedPartials);
 	            
             } else {
-            	
-                int[] states = new int[patternCount];
                 DataType dataType = alignment.getDataType();
                 for (int i = 0; i < patternCount; i++) {
                     int code = alignment.getPattern(taxonIndex, i);
                     int[] statesForCode = dataType.getStatesForCode(code);
                     if (statesForCode.length==1)
-                        states[i] = statesForCode[0];
+                        cachedStates[i] = statesForCode[0];
                     else
-                        states[i] = code; // Causes ambiguous states to be ignored.
+                        cachedStates[i] = code; // Causes ambiguous states to be ignored.
                 }
-                likelihoodCore.setNodeStates(nodeNr, states);
+                likelihoodCore.setNodeStates(nodeNr, cachedStates);
                 node.makeDirty(Tree.IS_DIRTY);
             }
         }
@@ -112,22 +115,21 @@ public class MATreeLikelihood extends TreeLikelihood {
 	 * to states encoded in sites
 	 */
 	public double [] getLogProbsForStateSequence(int nodeNr, int [] sites) {
-		// update data for node 
+		// update data for node
 		int patternCount = sites.length;
         if (m_useAmbiguities.get()) {
         	throw new IllegalArgumentException("should not use getLogProbsForSequence but getLogProbsForPartialsSequence instead");
         }
-        int[] states = new int[patternCount];
         DataType dataType = alignment.getDataType();
         for (int i = 0; i < patternCount; i++) {
             int code = sites[i];
             int[] statesForCode = dataType.getStatesForCode(code);
             if (statesForCode.length==1)
-                states[i] = statesForCode[0];
+                cachedStates[i] = statesForCode[0];
             else
-                states[i] = code; // Causes ambiguous states to be ignored.
+                cachedStates[i] = code; // Causes ambiguous states to be ignored.
         }
-        likelihoodCore.setNodeStates(nodeNr, states);
+        likelihoodCore.setNodeStates(nodeNr, cachedStates);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}

--- a/src/mutablealignment/MutableAlignment.java
+++ b/src/mutablealignment/MutableAlignment.java
@@ -353,7 +353,7 @@ public class MutableAlignment extends Alignment implements MutableAlignmentInter
 	@Override
 	public void assignFromFragile(StateNode other) {
 		MutableAlignment src = (MutableAlignment)other;
-		if (src.getPatternCount() != src.getPatternCount()) {
+		if (this.getPatternCount() != src.getPatternCount()) {
 			throw new IllegalArgumentException("assignFromFragile() Expected replacement to be of equal number of patterns (this is realy fragile)");
 		}
 		for (int i = 0; i < src.getPatternCount(); i++) {


### PR DESCRIPTION
## Summary

- Cache `operations`, `states`, and `partials` arrays as instance fields instead of allocating on every call in `BeagleMATreeLikelihood` and `MATreeLikelihood`
- The main culprit was `calcPatternLogLikelihoods()` allocating `new int[nodeCount * 7]` on every call — unique to the BEAGLE path, which explains why the leak was only observed with BEAGLE
- Fix bug in `MutableAlignment.assignFromFragile()` comparing `src` to itself

Fixes #5

## Test plan
- [ ] Run MCMC with MutableAlignment + BEAGLE and monitor memory usage
- [ ] Verify likelihood values are unchanged