### PR TITLE
Fix store restore for mutable tips in beast 2.7

### DIFF
--- a/docs/probe-store-restore.md
+++ b/docs/probe-store-restore.md
@@ -1,0 +1,153 @@
+# Probe APIs and the store/restore lifecycle
+
+`MATreeLikelihood.getLogProbsForStateSequence` (and its partials variant) is
+used by Gibbs-style operators to ask "what would the per-site log
+likelihoods be if taxon `k`'s sequence were `s`?" without committing to the
+proposed sequence. The probe walks from `k` up to the root, recomputing
+partials at every ancestor — which writes into BEAST2's `LikelihoodCore`
+buffers. This document explains how those writes interact with BEAST2's
+store/restore lifecycle and why the obvious-looking fix has subtle traps.
+
+## The buffer model
+
+`BeerLikelihoodCore` double-buffers internal-node partials with two
+per-node arrays and a `currentPartialsIndex[a]` (call it `c`) that selects
+the live slot, plus a `storedPartialsIndex[a]` (call it `s`) used by
+`restore()`. After `store()` (which copies `c → s`), both `c` and `s` point
+to the same data slot — that's the "stored" state to roll back to.
+
+`setNodePartialsForUpdate(a)` flips `c[a]`. The contract is: callers flip
+*before* writing new partials, so writes land in the scratch slot and the
+stored slot stays intact. `restore()` swaps the index arrays, which has
+the effect of pointing `c` back at the stored slot.
+
+Tip states (when `useAmbiguities=false`) are *not* double-buffered —
+there's a single `int[] states[nodeIndex]`. `MATreeLikelihood` patches over
+this with `tempTipNodes` (track which tips were probed) and resync from
+`MutableAlignment` in `restore()`.
+
+## Where the timing trap lives
+
+In one MCMC iteration, the framework calls (in order):
+
+1. `state.store(sample)` — bookkeeping only, doesn't touch CalculationNodes
+2. `operator.proposal()` — *probes happen here*
+3. `state.storeCalculationNodes()` → `MATreeLikelihood.store()` — **after** the proposal, **before** evaluation
+4. `posterior.calculateLogP()` → `MATreeLikelihood.calculateLogP()`
+5. accept → `acceptCalculationNodes()`, or reject → `state.restore()` + `restoreCalculationNodes()`
+
+Step 3 is the trap. Anything `store()` clears is wiped *between probes and
+calculateLogP*, so any probe-tracking state set up during step 2 must
+survive `store()`.
+
+## Buggy flow (commit `c99c8f8`, before `af09f09`)
+
+`store()` cleared `flippedNodes`, so the undo loop in `calculateLogP()`
+saw an empty set and never flipped back. The framework's traverse then
+flipped `c` again, rotating it back onto the stored slot and overwriting
+the genuine pre-store partials.
+
+```mermaid
+sequenceDiagram
+    participant MCMC
+    participant Op as Operator
+    participant MA as MATreeLikelihood
+    participant LC as likelihoodCore
+
+    Note over LC: partials[0]=A (current), partials[1]=junk<br/>c=0, s=0
+
+    MCMC->>Op: proposal()
+    Op->>MA: getLogProbsForStateSequence(...)
+    MA->>LC: setNodePartialsForUpdate(a) [c: 0→1]
+    Note right of MA: flippedNodes += a
+    MA->>LC: calculatePartials → writes partials[1][a]
+
+    Note over LC: partials[0]=A, partials[1]=probe<br/>c=1, s=0
+
+    rect rgb(255, 200, 200)
+    MCMC->>MA: store() 💥 clears flippedNodes
+    end
+
+    MCMC->>MA: calculateLogP()
+    Note right of MA: undo loop is empty — c stays at 1
+    MA->>LC: super.calculateLogP → traverse flips c again [c: 1→0]<br/>writes new state B into partials[0]
+
+    Note over LC: partials[0]=B (overwrote A!), partials[1]=probe<br/>c=0, s=0
+
+    MCMC->>LC: restore() swaps c↔s (no-op)
+    Note over LC: 💥 partials[0] is corrupt; next read returns B not A
+```
+
+## Fixed flow (commit `af09f09`)
+
+`store()` no longer clears `flippedNodes` / `tempTipNodes`. The undo loop
+in `calculateLogP()` flips `c` back to 0 *before* `super.calculateLogP()`
+runs, so the framework's traverse-time flip lands at `c=1` (scratch),
+leaving the stored slot intact.
+
+```mermaid
+sequenceDiagram
+    participant MCMC
+    participant Op as Operator
+    participant MA as MATreeLikelihood
+    participant LC as likelihoodCore
+
+    Note over LC: partials[0]=A (current), partials[1]=junk<br/>c=0, s=0
+
+    MCMC->>Op: proposal()
+    Op->>MA: getLogProbsForStateSequence(...)
+    MA->>LC: setNodePartialsForUpdate(a) [c: 0→1]
+    Note right of MA: flippedNodes += a
+    MA->>LC: calculatePartials → writes partials[1][a]
+
+    Note over LC: partials[0]=A, partials[1]=probe<br/>c=1, s=0
+
+    rect rgb(200, 255, 200)
+    MCMC->>MA: store() ✓ leaves flippedNodes alone
+    end
+
+    MCMC->>MA: calculateLogP()
+    Note right of MA: undo loop: setNodePartialsForUpdate(a) [c: 1→0]<br/>flippedNodes cleared
+    MA->>LC: super.calculateLogP → traverse flips c again [c: 0→1]<br/>writes new state B into partials[1]
+
+    Note over LC: partials[0]=A (intact!), partials[1]=B<br/>c=1, s=0
+
+    alt accept
+        MCMC->>MA: accept() → LC stores: s := c
+        Note over LC: partials[1]=B, c=s=1 ✓
+    else reject
+        MCMC->>LC: restore() swaps c↔s
+        Note over LC: c=0, s=1 → reads partials[0]=A ✓
+    end
+```
+
+## Why not a simpler design?
+
+A localized "flip up, compute, flip back" inside `calcPatternLogLikelihoods`
+would be self-contained and not need any cross-method state — except for
+two reasons:
+
+1. **Tip states are single-buffered in BEAST2.** `setNodeStatesForUpdate`
+   is a no-op in `BeerLikelihoodCore`, so probes that mutate leaf states
+   need `tempTipNodes` resync regardless. Localizing the partials half
+   without addressing tip states would only solve half the problem.
+2. **BEAGLE's tip states are not double-buffered either.** Even if we
+   changed `BeerLikelihoodCore` to double-buffer states, the BEAGLE path
+   (`BeagleMATreeLikelihood`) couldn't follow suit, so the workaround
+   would still be needed there. Diverging the two paths costs more than
+   the uniformity of the current design.
+
+## Edge case left open
+
+If an operator uses probes and then returns `Double.NEGATIVE_INFINITY`,
+MCMC's failure path calls `state.restore()` but skips
+`restoreCalculationNodes()` (when the operator's
+`requiresStateInitialisation()` is `true`, the default). `MA.restore()`
+never runs, so the tracking sets and probe-polluted scratch slots persist
+into the next iteration. The `flippedNodes.add(...)` dedup will then skip
+flips that should have happened, causing writes into the now-stored slot.
+
+This isn't triggered by `phylonco`'s `ExchangeGibbsOperator` (all its
+`NEGATIVE_INFINITY` early-returns happen *before* the first probe) but
+would bite any future operator that probes and then returns
+`NEGATIVE_INFINITY`.

--- a/docs/probe-store-restore.md
+++ b/docs/probe-store-restore.md
@@ -81,7 +81,7 @@ sequenceDiagram
     Note over LC: partials[0]=B (overwrote A!), partials[1]=probe<br/>c=0, s=0
 
     MCMC->>LC: restore swaps c and s
-    Note over LC: partials[0] is corrupt; next read returns B not A
+    Note over LC: partials[0] holds the corrupt value B instead of A
 ```
 
 ## Fixed flow (commit `af09f09`)

--- a/docs/probe-store-restore.md
+++ b/docs/probe-store-restore.md
@@ -30,9 +30,9 @@ the effect of pointing `c` back at the stored slot.
 Tip states (when `useAmbiguities=false`) are *not* double-buffered —
 there's a single `int[] states[nodeIndex]`. `MATreeLikelihood` patches over
 this with `tempTipNodes` (track which tips were probed) and resync from
-`MutableAlignment` in `restore()`.
+`MutableAlignment` in `restore()`. This piece is unavoidable.
 
-## Where the timing trap lives
+## The MCMC iteration timing
 
 In one MCMC iteration, the framework calls (in order):
 
@@ -42,16 +42,67 @@ In one MCMC iteration, the framework calls (in order):
 4. `posterior.calculateLogP()` → `MATreeLikelihood.calculateLogP()`
 5. accept → `acceptCalculationNodes()`, or reject → `state.restore()` + `restoreCalculationNodes()`
 
-Step 3 is the trap. Anything `store()` clears is wiped *between probes and
-calculateLogP*, so any probe-tracking state set up during step 2 must
-survive `store()`.
+Step 3 is the trap of an earlier design (see history below). Anything
+`store()` clears is wiped *between probes and calculateLogP* — so any
+probe-tracking state set up during step 2 must either (a) survive `store()`
+or (b) be eliminated entirely before `store()` is called. The current code
+takes path (b) for partials.
 
-## Buggy flow (commit `c99c8f8`, before `af09f09`)
+## Current design (commit `66e8b99` and later): hermetic probes
 
-`store()` cleared `flippedNodes`, so the undo loop in `calculateLogP()`
-saw an empty set and never flipped back. The framework's traverse then
-flipped `c` again, rotating it back onto the stored slot and overwriting
-the genuine pre-store partials.
+`calcPatternLogLikelihoods` is now hermetic: it flips each touched
+ancestor's partials index to the scratch slot before writing, computes
+pattern log likelihoods at the root, then flips each ancestor back. After
+the probe call returns, the partials indices are exactly what they were
+on entry — the probe leaves *no trace* in the `LikelihoodCore`'s buffer
+indices for the framework's store/restore to mishandle.
+
+```mermaid
+sequenceDiagram
+    participant MCMC
+    participant Op as Operator
+    participant MA as MATreeLikelihood
+    participant LC as likelihoodCore
+
+    Note over LC: partials[0]=A (current), partials[1]=junk<br/>c=0, s=0
+
+    MCMC->>Op: proposal()
+    Op->>MA: getLogProbsForStateSequence(...)
+    MA->>LC: setNodePartialsForUpdate(a) [c: 0→1]
+    MA->>LC: calculatePartials → writes partials[1][a]
+    Note over LC: partials[0]=A, partials[1]=probe<br/>c=1, s=0
+    MA->>LC: setNodePartialsForUpdate(a) [c: 1→0]
+    Note over LC: partials[0]=A, partials[1]=probe orphaned<br/>c=0, s=0 (back to entry)
+
+    MCMC->>MA: store ok, no partials state to preserve
+
+    MCMC->>MA: calculateLogP()
+    MA->>LC: super.calculateLogP → traverse flips c again [c: 0→1]<br/>writes new state B into partials[1]
+    Note over LC: partials[0]=A (intact!), partials[1]=B<br/>c=1, s=0
+
+    alt accept
+        MCMC->>MA: accept → LC stores: s := c
+        Note over LC: partials[1]=B, c=s=1
+    else reject
+        MCMC->>LC: restore swaps c and s
+        Note over LC: c=0, s=1 -- reads partials[0]=A
+    end
+```
+
+For tip states, `tempTipNodes` is still needed and `store()` must not
+clear it — that is the one cross-method invariant left.
+
+## Earlier design (commits `0a33bb7`/`c99c8f8`/`af09f09`)
+
+Earlier versions tracked flipped ancestors in a class-level
+`flippedNodes` Set and undid the flips in an explicit loop at the start
+of `calculateLogP()`. That worked in principle, but commits `0a33bb7` and
+`c99c8f8` cleared `flippedNodes` inside `store()` — wiping the tracking
+between probes and the undo loop. The framework's traverse then flipped
+`c` a *second* time, rotating it back onto the stored slot and
+overwriting the genuine pre-store partials. The bug surfaced as a
+likelihood mismatch in `phylonco`'s `ExchangeGibbsOperator` (cached
+−541.026 vs fresh −570.892, Δ 29.87).
 
 ```mermaid
 sequenceDiagram
@@ -67,7 +118,6 @@ sequenceDiagram
     MA->>LC: setNodePartialsForUpdate(a) [c: 0→1]
     Note right of MA: flippedNodes += a
     MA->>LC: calculatePartials → writes partials[1][a]
-
     Note over LC: partials[0]=A, partials[1]=probe<br/>c=1, s=0
 
     rect rgb(255, 200, 200)
@@ -75,73 +125,34 @@ sequenceDiagram
     end
 
     MCMC->>MA: calculateLogP()
-    Note right of MA: undo loop is empty — c stays at 1
+    Note right of MA: undo loop is empty -- c stays at 1
     MA->>LC: super.calculateLogP → traverse flips c again [c: 1→0]<br/>writes new state B into partials[0]
-
     Note over LC: partials[0]=B (overwrote A!), partials[1]=probe<br/>c=0, s=0
 
     MCMC->>LC: restore swaps c and s
     Note over LC: partials[0] holds the corrupt value B instead of A
 ```
 
-## Fixed flow (commit `af09f09`)
+`af09f09` patched the immediate symptom by removing the two `clear()`
+calls in `store()`. `66e8b99` then refactored to the hermetic design
+above, eliminating the cross-method partials state altogether.
 
-`store()` no longer clears `flippedNodes` / `tempTipNodes`. The undo loop
-in `calculateLogP()` flips `c` back to 0 *before* `super.calculateLogP()`
-runs, so the framework's traverse-time flip lands at `c=1` (scratch),
-leaving the stored slot intact.
+## Why this is the cleanest available design
 
-```mermaid
-sequenceDiagram
-    participant MCMC
-    participant Op as Operator
-    participant MA as MATreeLikelihood
-    participant LC as likelihoodCore
-
-    Note over LC: partials[0]=A (current), partials[1]=junk<br/>c=0, s=0
-
-    MCMC->>Op: proposal()
-    Op->>MA: getLogProbsForStateSequence(...)
-    MA->>LC: setNodePartialsForUpdate(a) [c: 0→1]
-    Note right of MA: flippedNodes += a
-    MA->>LC: calculatePartials → writes partials[1][a]
-
-    Note over LC: partials[0]=A, partials[1]=probe<br/>c=1, s=0
-
-    rect rgb(200, 255, 200)
-    MCMC->>MA: store() ✓ leaves flippedNodes alone
-    end
-
-    MCMC->>MA: calculateLogP()
-    Note right of MA: undo loop: setNodePartialsForUpdate(a) [c: 1→0]<br/>flippedNodes cleared
-    MA->>LC: super.calculateLogP → traverse flips c again [c: 0→1]<br/>writes new state B into partials[1]
-
-    Note over LC: partials[0]=A (intact!), partials[1]=B<br/>c=1, s=0
-
-    alt accept
-        MCMC->>MA: accept() → LC stores: s := c
-        Note over LC: partials[1]=B, c=s=1 ✓
-    else reject
-        MCMC->>LC: restore() swaps c↔s
-        Note over LC: c=0, s=1 → reads partials[0]=A ✓
-    end
-```
-
-## Why not a simpler design?
-
-A localized "flip up, compute, flip back" inside `calcPatternLogLikelihoods`
-would be self-contained and not need any cross-method state — except for
-two reasons:
-
-1. **Tip states are single-buffered in BEAST2.** `setNodeStatesForUpdate`
-   is a no-op in `BeerLikelihoodCore`, so probes that mutate leaf states
-   need `tempTipNodes` resync regardless. Localizing the partials half
-   without addressing tip states would only solve half the problem.
-2. **BEAGLE's tip states are not double-buffered either.** Even if we
-   changed `BeerLikelihoodCore` to double-buffer states, the BEAGLE path
-   (`BeagleMATreeLikelihood`) couldn't follow suit, so the workaround
-   would still be needed there. Diverging the two paths costs more than
-   the uniformity of the current design.
+- **Tip states must use `tempTipNodes`.** `setNodeStatesForUpdate` is a
+  no-op in `BeerLikelihoodCore`, so probes that mutate leaf states have
+  to resync from `MutableAlignment` in `restore()` regardless of what
+  partials handling we choose. BEAGLE's tip states aren't double-buffered
+  either, so the `BeagleMATreeLikelihood` path needs the same workaround.
+- **Partials don't need cross-method state.** The "flip up, compute,
+  flip back" pattern is local to `calcPatternLogLikelihoods` and leaves
+  no cross-method invariants (other than the one tip-state set we already
+  need). No `store()`/`accept()`/`restore()` machinery to keep in sync;
+  no don't-clear-in-store trap to remember.
+- **BEAGLE's rescale recursion is handled** by threading the per-call
+  `flipped` set through the recursive call, so each ancestor is still
+  flipped at most once across rescale attempts and flipped back exactly
+  once on the final success path.
 
 ## Edge case left open
 
@@ -149,11 +160,17 @@ If an operator uses probes and then returns `Double.NEGATIVE_INFINITY`,
 MCMC's failure path calls `state.restore()` but skips
 `restoreCalculationNodes()` (when the operator's
 `requiresStateInitialisation()` is `true`, the default). `MA.restore()`
-never runs, so the tracking sets and probe-polluted scratch slots persist
-into the next iteration. The `flippedNodes.add(...)` dedup will then skip
-flips that should have happened, causing writes into the now-stored slot.
+never runs, so `tempTipNodes` is not cleared and the tip states are not
+resynced.
+
+For partials this is now harmless — the hermetic flip-up/flip-back
+already happened inside the probe call, so the buffer indices are clean.
+For tip states, the next probe in the next iteration would write fresh
+states (overwriting the stale ones) before computing, so single-probe
+operators still get the right answer. Cross-iteration state leakage of
+`tempTipNodes` is a small leak, not a correctness bug.
 
 This isn't triggered by `phylonco`'s `ExchangeGibbsOperator` (all its
 `NEGATIVE_INFINITY` early-returns happen *before* the first probe) but
-would bite any future operator that probes and then returns
-`NEGATIVE_INFINITY`.
+worth knowing if any future probe-using operator returns
+`NEGATIVE_INFINITY` post-probe.

--- a/docs/probe-store-restore.md
+++ b/docs/probe-store-restore.md
@@ -71,7 +71,7 @@ sequenceDiagram
     Note over LC: partials[0]=A, partials[1]=probe<br/>c=1, s=0
 
     rect rgb(255, 200, 200)
-    MCMC->>MA: store() 💥 clears flippedNodes
+    MCMC->>MA: store clears flippedNodes (BUG)
     end
 
     MCMC->>MA: calculateLogP()
@@ -80,8 +80,8 @@ sequenceDiagram
 
     Note over LC: partials[0]=B (overwrote A!), partials[1]=probe<br/>c=0, s=0
 
-    MCMC->>LC: restore() swaps c↔s (no-op)
-    Note over LC: 💥 partials[0] is corrupt; next read returns B not A
+    MCMC->>LC: restore swaps c and s
+    Note over LC: partials[0] is corrupt; next read returns B not A
 ```
 
 ## Fixed flow (commit `af09f09`)

--- a/docs/probe-store-restore.md
+++ b/docs/probe-store-restore.md
@@ -1,12 +1,18 @@
 # Probe APIs and the store/restore lifecycle
 
-`MATreeLikelihood.getLogProbsForStateSequence` (and its partials variant) is
-used by Gibbs-style operators to ask "what would the per-site log
-likelihoods be if taxon `k`'s sequence were `s`?" without committing to the
-proposed sequence. The probe walks from `k` up to the root, recomputing
-partials at every ancestor — which writes into BEAST2's `LikelihoodCore`
-buffers. This document explains how those writes interact with BEAST2's
-store/restore lifecycle and why the obvious-looking fix has subtle traps.
+In this document, **probe** means a speculative call to
+`MATreeLikelihood.getLogProbsForStateSequence(nodeNr, sites)` (or its
+partials variant `getLogProbsForPartialsSequence`): the caller is asking
+*what would the per-site log likelihoods be if leaf `nodeNr` had this
+sequence?* without committing to it as the new state. Gibbs-style
+operators issue many such probes per proposal to build up their proposal
+distribution.
+
+The probe walks from `nodeNr` up to the root, recomputing partials at
+every ancestor — which writes into BEAST2's `LikelihoodCore` buffers.
+That side effect is the source of all the subtleties below: it has to be
+managed against BEAST2's store/restore lifecycle so that the cached
+partials representing the current accepted state survive untouched.
 
 ## The buffer model
 

--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -21,10 +21,17 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	private int[] cachedStates;
 	private double[] cachedPartials;
 
+	// Mapping from alignment column index to tree leaf node number, and
+	// inverse. Computed once in initAndValidate by taxon name; alignment
+	// column order and tree leaf order are independent.
+	private int[] alignmentIdxToTreeNodeNr;
+	private int[] treeNodeNrToAlignmentIdx;
+
 	// Tracks tip nodes whose states were transiently overwritten by
 	// getLogProbs*Sequence during a proposal, so restore()/accept() can re-sync
 	// them from the (post-store/restore) alignment. BEAGLE's tip states are
 	// not double-buffered, so this resync mechanism is unavoidable.
+	// Stored as alignment column indices, matching dirtySequences.
 	private final Set<Integer> tempTipNodes = new HashSet<>();
 
 	@Override
@@ -43,6 +50,24 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 		cachedStates = new int[patternCount];
 		cachedPartials = new double[patternCount * stateCount];
 		cachedOperations = new int[treeInput.get().getNodeCount() * Beagle.OPERATION_TUPLE_SIZE];
+
+		buildTaxonIndexMaps();
+	}
+
+	private void buildTaxonIndexMaps() {
+		int taxonCount = alignment.getTaxonCount();
+		alignmentIdxToTreeNodeNr = new int[taxonCount];
+		treeNodeNrToAlignmentIdx = new int[taxonCount];
+		TreeInterface tree = treeInput.get();
+		for (Node leaf : tree.getExternalNodes()) {
+			int nodeNr = leaf.getNr();
+			int alignIdx = alignment.getTaxonIndex(leaf.getID());
+			if (alignIdx < 0) {
+				throw new RuntimeException("Tree leaf " + leaf.getID() + " not found in alignment");
+			}
+			alignmentIdxToTreeNodeNr[alignIdx] = nodeNr;
+			treeNodeNrToAlignmentIdx[nodeNr] = alignIdx;
+		}
 	}
 		
 	@Override
@@ -78,9 +103,10 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
         TreeInterface tree = treeInput.get();
     	int patternCount = alignment.getPatternCount();
         int stateCount = alignment.getDataType().getStateCount();
-    	for (int nodeNr: dirtySequences) {
+    	for (int taxonIndex: dirtySequences) {
+    		// dirtySequences holds alignment column indices.
+    		int nodeNr = alignmentIdxToTreeNodeNr[taxonIndex];
     		Node node = tree.getNode(nodeNr);
-            int taxonIndex = alignment.getTaxonIndex(node.getID());
 
             if (m_useAmbiguities.get()) {
 	            int k = 0;
@@ -136,7 +162,7 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
                 cachedStates[i] = code; // Causes ambiguous states to be ignored.
         }
         beagle.setTipStates(nodeNr, cachedStates);
-        tempTipNodes.add(nodeNr);
+        tempTipNodes.add(treeNodeNrToAlignmentIdx[nodeNr]);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
@@ -147,7 +173,7 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	 */
 	public double [] getLogProbsForPartialsSequence(int nodeNr, double [] tipLikelihoods) {
         beagle.setPartials(nodeNr, tipLikelihoods);
-        tempTipNodes.add(nodeNr);
+        tempTipNodes.add(treeNodeNrToAlignmentIdx[nodeNr]);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}

--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -362,8 +362,12 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	@Override
 	public void store() {
     	dirtySequences.clear();
-    	tempTipNodes.clear();
-    	flippedNodes.clear();
+    	// Do NOT clear tempTipNodes / flippedNodes here. store() is called by MCMC
+    	// between operator.proposal() and calculateLogP() (default
+    	// requiresStateInitialisation=true). Probes happen during proposal, so
+    	// clearing here would lose the tracking needed to undo probe-time buffer
+    	// flips before super.calculateLogP() runs. Both sets are cleared by
+    	// calculateLogP() (after the undo) and by accept()/restore().
 
     	super.store();
 	}

--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -23,13 +23,9 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 
 	// Tracks tip nodes whose states were transiently overwritten by
 	// getLogProbs*Sequence during a proposal, so restore()/accept() can re-sync
-	// them from the (post-store/restore) alignment.
+	// them from the (post-store/restore) alignment. BEAGLE's tip states are
+	// not double-buffered, so this resync mechanism is unavoidable.
 	private final Set<Integer> tempTipNodes = new HashSet<>();
-
-	// Tracks internal nodes whose partials buffer has already been flipped during
-	// the current proposal. Each node must be flipped at most once per proposal:
-	// flipping twice rotates back to the stored slot and overwrites it.
-	private final Set<Integer> flippedNodes = new HashSet<>();
 
 	@Override
 	public void initAndValidate() {
@@ -55,16 +51,6 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 			updateAlignment();
 			alignmentNeedsUpdate = false;
 		}
-		// Undo probe-time partials-buffer flips before super.calculateLogP() runs.
-		// Reason: BeagleTreeLikelihood's traverse() calls partialBufferHelper.flipOffset()
-		// for every dirty ancestor, which toggles the partials offset again. Without
-		// this undo, ancestors flipped by getLogProbs*Sequence get flipped twice in
-		// one proposal, rotating the current offset back to the stored slot and
-		// clobbering it.
-		for (Integer n : flippedNodes) {
-			partialBufferHelper.flipOffset(n);
-		}
-		flippedNodes.clear();
 		logP = super.calculateLogP();
 		
 		
@@ -167,10 +153,20 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	}
 
 	
-	// propagate changes from a leaf node set by getLogProbsForStateSequence or 
-	// getLogProbsForPartialsSequence to the root and return updated pattern log 
-	// likelihoods
+	// propagate changes from a leaf node set by getLogProbsForStateSequence or
+	// getLogProbsForPartialsSequence to the root and return updated pattern log
+	// likelihoods. Hermetic: flips each touched ancestor's partials offset to
+	// the scratch slot before writing, computes pattern log likelihoods at the
+	// root, then flips each ancestor back. After this method returns the
+	// partialBufferHelper offsets are exactly what they were on entry.
 	private double [] calcPatternLogLikelihoods(int nodeNr) {
+		return calcPatternLogLikelihoods(nodeNr, new HashSet<>());
+	}
+
+	// Inner overload threads the per-call `flipped` set through the rescale
+	// recursion so we still flip each ancestor at most once across attempts
+	// (and flip them all back on the final success path).
+	private double [] calcPatternLogLikelihoods(int nodeNr, Set<Integer> flipped) {
 
         Node node = treeInput.get().getNode(nodeNr);
         int operationCount = 0;
@@ -188,7 +184,7 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 
             // Flip to scratch slot so we don't overwrite partials captured by store().
             // Flip at most once per node per proposal (toggling twice would clobber the stored slot).
-            if (flippedNodes.add(nodeNr)) {
+            if (flipped.add(nodeNr)) {
                 partialBufferHelper.flipOffset(nodeNr);
             }
             operations[x] = partialBufferHelper.getOffsetIndex(nodeNr);
@@ -340,7 +336,9 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
                     // traverse again but without flipping partials indices as we
                     // just want to overwrite the last attempt. We will flip the
                     // scale buffer indices though as we are recomputing them.
-                    return calcPatternLogLikelihoods(nodeNr);
+                    // Pass `flipped` so the recursion's add() check skips
+                    // re-flipping the ancestors we already toggled.
+                    return calcPatternLogLikelihoods(nodeNr, flipped);
 
 //                    done = false; // Run through do-while loop again
 //                    firstRescaleAttempt = false; // Only try to rescale once
@@ -355,6 +353,11 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 
         } while (!done);
 
+        // flip ancestors back so the partials offsets are unchanged on exit
+        for (Integer nr : flipped) {
+            partialBufferHelper.flipOffset(nr);
+        }
+
         return patternLogLikelihoods.clone();
     }
 
@@ -362,12 +365,11 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	@Override
 	public void store() {
     	dirtySequences.clear();
-    	// Do NOT clear tempTipNodes / flippedNodes here. store() is called by MCMC
-    	// between operator.proposal() and calculateLogP() (default
-    	// requiresStateInitialisation=true). Probes happen during proposal, so
-    	// clearing here would lose the tracking needed to undo probe-time buffer
-    	// flips before super.calculateLogP() runs. Both sets are cleared by
-    	// calculateLogP() (after the undo) and by accept()/restore().
+    	// Do NOT clear tempTipNodes here. store() is called by MCMC between
+    	// operator.proposal() and calculateLogP() (default
+    	// requiresStateInitialisation=true). Tip-state probes happen during
+    	// proposal, and the resync needs to know which tips were touched until
+    	// restore()/accept() handles them.
 
     	super.store();
 	}
@@ -388,14 +390,12 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
     	updateTipData();
     	dirtySequences.clear();
     	tempTipNodes.clear();
-    	flippedNodes.clear();
 	}
 
 	@Override
 	protected void accept() {
     	dirtySequences.clear();
     	tempTipNodes.clear();
-    	flippedNodes.clear();
 		alignment.accept();
 		super.accept();
 	}

--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -404,15 +404,14 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	public void restore() {
 		super.restore();
 
-    	// Resync every tip we temporarily mutated (via getLogProbs*Sequence) from
-    	// the alignment, which has itself just been rolled back. This is a superset
-    	// of alignment.getDirtySequenceIndices() because getLogProbs* may probe tips
-    	// that weren't alignment-dirty (e.g. the partials-fixup leaf).
-    	dirtySequences.clear();
+    	// Resync every tip we temporarily mutated from the (now-rolled-back)
+    	// alignment. dirtySequences was populated during the previous
+    	// calculateLogP from alignment.getDirtySequenceIndices(); we can't
+    	// re-query that here because alignment.restore() has already cleared
+    	// the edit list. Add probe-touched tips (tempTipNodes) since they may
+    	// not have been alignment-dirty (e.g. ExchangeGibbsOperator's partials-
+    	// fixup leaf).
     	dirtySequences.addAll(tempTipNodes);
-    	for (Integer i : alignment.getDirtySequenceIndices()) {
-    		dirtySequences.add(i);
-    	}
     	updateTipData();
     	dirtySequences.clear();
     	tempTipNodes.clear();

--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -55,6 +55,16 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 			updateAlignment();
 			alignmentNeedsUpdate = false;
 		}
+		// Undo probe-time partials-buffer flips before super.calculateLogP() runs.
+		// Reason: BeagleTreeLikelihood's traverse() calls partialBufferHelper.flipOffset()
+		// for every dirty ancestor, which toggles the partials offset again. Without
+		// this undo, ancestors flipped by getLogProbs*Sequence get flipped twice in
+		// one proposal, rotating the current offset back to the stored slot and
+		// clobbering it.
+		for (Integer n : flippedNodes) {
+			partialBufferHelper.flipOffset(n);
+		}
+		flippedNodes.clear();
 		logP = super.calculateLogP();
 		
 		

--- a/src/mutablealignment/BeagleMATreeLikelihood.java
+++ b/src/mutablealignment/BeagleMATreeLikelihood.java
@@ -1,7 +1,9 @@
 package mutablealignment;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import beagle.Beagle;
 import beast.base.core.Description;
@@ -18,6 +20,16 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	private int[] cachedOperations;
 	private int[] cachedStates;
 	private double[] cachedPartials;
+
+	// Tracks tip nodes whose states were transiently overwritten by
+	// getLogProbs*Sequence during a proposal, so restore()/accept() can re-sync
+	// them from the (post-store/restore) alignment.
+	private final Set<Integer> tempTipNodes = new HashSet<>();
+
+	// Tracks internal nodes whose partials buffer has already been flipped during
+	// the current proposal. Each node must be flipped at most once per proposal:
+	// flipping twice rotates back to the stored slot and overwrites it.
+	private final Set<Integer> flippedNodes = new HashSet<>();
 
 	@Override
 	public void initAndValidate() {
@@ -128,16 +140,18 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
                 cachedStates[i] = code; // Causes ambiguous states to be ignored.
         }
         beagle.setTipStates(nodeNr, cachedStates);
+        tempTipNodes.add(nodeNr);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
 
 	/*
-	 * returns pattern log likelihoods after setting sequence for node with given nodeNr 
+	 * returns pattern log likelihoods after setting sequence for node with given nodeNr
 	 * to states encoded in sites
 	 */
 	public double [] getLogProbsForPartialsSequence(int nodeNr, double [] tipLikelihoods) {
         beagle.setPartials(nodeNr, tipLikelihoods);
+        tempTipNodes.add(nodeNr);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
@@ -162,6 +176,11 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 
             int x = operationCount * Beagle.OPERATION_TUPLE_SIZE;
 
+            // Flip to scratch slot so we don't overwrite partials captured by store().
+            // Flip at most once per node per proposal (toggling twice would clobber the stored slot).
+            if (flippedNodes.add(nodeNr)) {
+                partialBufferHelper.flipOffset(nodeNr);
+            }
             operations[x] = partialBufferHelper.getOffsetIndex(nodeNr);
 
             if (useScaleFactors) {
@@ -333,21 +352,36 @@ public class BeagleMATreeLikelihood extends BeagleTreeLikelihood {
 	@Override
 	public void store() {
     	dirtySequences.clear();
+    	tempTipNodes.clear();
+    	flippedNodes.clear();
 
     	super.store();
 	}
-	
+
 	@Override
 	public void restore() {
 		super.restore();
-		
+
+    	// Resync every tip we temporarily mutated (via getLogProbs*Sequence) from
+    	// the alignment, which has itself just been rolled back. This is a superset
+    	// of alignment.getDirtySequenceIndices() because getLogProbs* may probe tips
+    	// that weren't alignment-dirty (e.g. the partials-fixup leaf).
+    	dirtySequences.clear();
+    	dirtySequences.addAll(tempTipNodes);
+    	for (Integer i : alignment.getDirtySequenceIndices()) {
+    		dirtySequences.add(i);
+    	}
     	updateTipData();
     	dirtySequences.clear();
+    	tempTipNodes.clear();
+    	flippedNodes.clear();
 	}
-	
+
 	@Override
 	protected void accept() {
     	dirtySequences.clear();
+    	tempTipNodes.clear();
+    	flippedNodes.clear();
 		alignment.accept();
 		super.accept();
 	}

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -57,6 +57,15 @@ public class MATreeLikelihood extends TreeLikelihood {
 			updateAlignment();
 			alignmentNeedsUpdate = false;
 		}
+		// Undo probe-time partials toggles before super.calculateLogP() runs.
+		// Reason: traverse() calls setNodePartialsForUpdate() for every dirty
+		// ancestor, which toggles the partials-index again. Without this undo,
+		// ancestors toggled by getLogProbs*Sequence get toggled twice in one
+		// proposal, rotating current back to the stored slot and clobbering it.
+		for (Integer n : flippedNodes) {
+			likelihoodCore.setNodePartialsForUpdate(n);
+		}
+		flippedNodes.clear();
 		logP = super.calculateLogP();
 		
 		

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -21,11 +21,18 @@ public class MATreeLikelihood extends TreeLikelihood {
 	private int[] cachedStates;
 	private double[] cachedPartials;
 
+	// Mapping from alignment column index to tree leaf node number, and
+	// inverse. Computed once in initAndValidate by taxon name; alignment
+	// column order and tree leaf order are independent.
+	private int[] alignmentIdxToTreeNodeNr;
+	private int[] treeNodeNrToAlignmentIdx;
+
 	// Tracks tip nodes whose states were transiently overwritten by
 	// getLogProbs*Sequence during a proposal, so restore()/accept() can re-sync
 	// them from the (post-store/restore) alignment. Tip states are
 	// single-buffered in BeerLikelihoodCore -- there is no flip-back trick
 	// available -- so this resync mechanism is unavoidable.
+	// Stored as alignment column indices, matching dirtySequences.
 	private final Set<Integer> tempTipNodes = new HashSet<>();
 
 	@Override
@@ -46,6 +53,24 @@ public class MATreeLikelihood extends TreeLikelihood {
 		int stateCount = alignment.getDataType().getStateCount();
 		cachedStates = new int[patternCount];
 		cachedPartials = new double[patternCount * stateCount];
+
+		buildTaxonIndexMaps();
+	}
+
+	private void buildTaxonIndexMaps() {
+		int taxonCount = alignment.getTaxonCount();
+		alignmentIdxToTreeNodeNr = new int[taxonCount];
+		treeNodeNrToAlignmentIdx = new int[taxonCount];
+		TreeInterface tree = treeInput.get();
+		for (Node leaf : tree.getExternalNodes()) {
+			int nodeNr = leaf.getNr();
+			int alignIdx = alignment.getTaxonIndex(leaf.getID());
+			if (alignIdx < 0) {
+				throw new RuntimeException("Tree leaf " + leaf.getID() + " not found in alignment");
+			}
+			alignmentIdxToTreeNodeNr[alignIdx] = nodeNr;
+			treeNodeNrToAlignmentIdx[nodeNr] = alignIdx;
+		}
 	}
 		
 	@Override
@@ -81,9 +106,10 @@ public class MATreeLikelihood extends TreeLikelihood {
         TreeInterface tree = treeInput.get();
     	int patternCount = alignment.getPatternCount();
         int stateCount = alignment.getDataType().getStateCount();
-    	for (int nodeNr: dirtySequences) {
+    	for (int taxonIndex: dirtySequences) {
+    		// dirtySequences holds alignment column indices.
+    		int nodeNr = alignmentIdxToTreeNodeNr[taxonIndex];
     		Node node = tree.getNode(nodeNr);
-            int taxonIndex = alignment.getTaxonIndex(node.getID());
 
             if (m_useAmbiguities.get()) {
 	            int k = 0;
@@ -139,7 +165,7 @@ public class MATreeLikelihood extends TreeLikelihood {
                 cachedStates[i] = code; // Causes ambiguous states to be ignored.
         }
         likelihoodCore.setNodeStates(nodeNr, cachedStates);
-        tempTipNodes.add(nodeNr);
+        tempTipNodes.add(treeNodeNrToAlignmentIdx[nodeNr]);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
@@ -150,7 +176,7 @@ public class MATreeLikelihood extends TreeLikelihood {
 	 */
 	public double [] getLogProbsForPartialsSequence(int nodeNr, double [] tipLikelihoods) {
         likelihoodCore.setNodePartials(nodeNr, tipLikelihoods);
-        tempTipNodes.add(nodeNr);
+        tempTipNodes.add(treeNodeNrToAlignmentIdx[nodeNr]);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -211,8 +211,12 @@ public class MATreeLikelihood extends TreeLikelihood {
 	@Override
 	public void store() {
     	dirtySequences.clear();
-    	tempTipNodes.clear();
-    	flippedNodes.clear();
+    	// Do NOT clear tempTipNodes / flippedNodes here. store() is called by MCMC
+    	// between operator.proposal() and calculateLogP() (default
+    	// requiresStateInitialisation=true). Probes happen during proposal, so
+    	// clearing here would lose the tracking needed to undo probe-time buffer
+    	// flips before super.calculateLogP() runs. Both sets are cleared by
+    	// calculateLogP() (after the undo) and by accept()/restore().
 
     	super.store();
 	}

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -23,13 +23,10 @@ public class MATreeLikelihood extends TreeLikelihood {
 
 	// Tracks tip nodes whose states were transiently overwritten by
 	// getLogProbs*Sequence during a proposal, so restore()/accept() can re-sync
-	// them from the (post-store/restore) alignment.
+	// them from the (post-store/restore) alignment. Tip states are
+	// single-buffered in BeerLikelihoodCore -- there is no flip-back trick
+	// available -- so this resync mechanism is unavoidable.
 	private final Set<Integer> tempTipNodes = new HashSet<>();
-
-	// Tracks internal nodes whose partials buffer has already been flipped during
-	// the current proposal. Each node must be flipped at most once per proposal:
-	// flipping twice rotates back to the stored slot and overwrites it.
-	private final Set<Integer> flippedNodes = new HashSet<>();
 
 	@Override
 	public void initAndValidate() {
@@ -57,15 +54,6 @@ public class MATreeLikelihood extends TreeLikelihood {
 			updateAlignment();
 			alignmentNeedsUpdate = false;
 		}
-		// Undo probe-time partials toggles before super.calculateLogP() runs.
-		// Reason: traverse() calls setNodePartialsForUpdate() for every dirty
-		// ancestor, which toggles the partials-index again. Without this undo,
-		// ancestors toggled by getLogProbs*Sequence get toggled twice in one
-		// proposal, rotating current back to the stored slot and clobbering it.
-		for (Integer n : flippedNodes) {
-			likelihoodCore.setNodePartialsForUpdate(n);
-		}
-		flippedNodes.clear();
 		logP = super.calculateLogP();
 		
 		
@@ -168,23 +156,26 @@ public class MATreeLikelihood extends TreeLikelihood {
 	}
 
 	
-	// propagate changes from a leaf node set by getLogProbsForStateSequence or 
-	// getLogProbsForPartialsSequence to the root and return updated pattern log 
-	// likelihoods
+	// propagate changes from a leaf node set by getLogProbsForStateSequence or
+	// getLogProbsForPartialsSequence to the root and return updated pattern log
+	// likelihoods. Hermetic: flips each touched ancestor's partials index to
+	// the scratch slot before writing, computes pattern log likelihoods at the
+	// root, then flips each ancestor back. After this method returns the
+	// likelihoodCore's partials indices are exactly what they were on entry,
+	// so the probe leaves no trace for the framework's store/restore to mishandle.
 	private double [] calcPatternLogLikelihoods(int nodeNr) {
-        // calculate partials up to the root
+        // calculate partials up to the root, flipping each ancestor to its
+        // scratch slot so we don't overwrite the stored state
+        final List<Integer> flipped = new ArrayList<>();
         Node node = treeInput.get().getNode(nodeNr);
         do {
         	node = node.getParent();
         	final int parentNr = node.getNr();
-        	// Flip to scratch buffer so we don't overwrite partials captured by store().
-        	// Flip at most once per node per proposal (toggling twice would clobber the stored slot).
-        	if (flippedNodes.add(parentNr)) {
-        		likelihoodCore.setNodePartialsForUpdate(parentNr);
-        	}
+        	likelihoodCore.setNodePartialsForUpdate(parentNr);
+        	flipped.add(parentNr);
             likelihoodCore.calculatePartials(node.getLeft().getNr(), node.getRight().getNr(), parentNr);
         } while (!node.isRoot());
-        
+
         // do fiddly bits at the root
         final double[] proportions = m_siteModel.getCategoryProportions(node);
         likelihoodCore.integratePartials(node.getNr(), proportions, m_fRootPartials);
@@ -204,6 +195,11 @@ public class MATreeLikelihood extends TreeLikelihood {
         }
         likelihoodCore.calculateLogLikelihoods(m_fRootPartials, rootFrequencies, patternLogLikelihoods);
 
+        // flip ancestors back so the partials indices are unchanged on exit
+        for (Integer nr : flipped) {
+        	likelihoodCore.setNodePartialsForUpdate(nr);
+        }
+
 		return getPatternLogLikelihoods();
 	}
 	
@@ -211,12 +207,11 @@ public class MATreeLikelihood extends TreeLikelihood {
 	@Override
 	public void store() {
     	dirtySequences.clear();
-    	// Do NOT clear tempTipNodes / flippedNodes here. store() is called by MCMC
-    	// between operator.proposal() and calculateLogP() (default
-    	// requiresStateInitialisation=true). Probes happen during proposal, so
-    	// clearing here would lose the tracking needed to undo probe-time buffer
-    	// flips before super.calculateLogP() runs. Both sets are cleared by
-    	// calculateLogP() (after the undo) and by accept()/restore().
+    	// Do NOT clear tempTipNodes here. store() is called by MCMC between
+    	// operator.proposal() and calculateLogP() (default
+    	// requiresStateInitialisation=true). Tip-state probes happen during
+    	// proposal, and the resync needs to know which tips were touched until
+    	// restore()/accept() handles them.
 
     	super.store();
 	}
@@ -237,14 +232,12 @@ public class MATreeLikelihood extends TreeLikelihood {
     	updateTipData();
     	dirtySequences.clear();
     	tempTipNodes.clear();
-    	flippedNodes.clear();
 	}
 
 	@Override
 	protected void accept() {
     	dirtySequences.clear();
     	tempTipNodes.clear();
-    	flippedNodes.clear();
 		alignment.accept();
 		super.accept();
 	}

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -2,7 +2,9 @@ package mutablealignment;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import beast.base.core.Description;
 import beast.base.evolution.datatype.DataType;
@@ -18,6 +20,16 @@ public class MATreeLikelihood extends TreeLikelihood {
 	private boolean alignmentNeedsUpdate;
 	private int[] cachedStates;
 	private double[] cachedPartials;
+
+	// Tracks tip nodes whose states were transiently overwritten by
+	// getLogProbs*Sequence during a proposal, so restore()/accept() can re-sync
+	// them from the (post-store/restore) alignment.
+	private final Set<Integer> tempTipNodes = new HashSet<>();
+
+	// Tracks internal nodes whose partials buffer has already been flipped during
+	// the current proposal. Each node must be flipped at most once per proposal:
+	// flipping twice rotates back to the stored slot and overwrites it.
+	private final Set<Integer> flippedNodes = new HashSet<>();
 
 	@Override
 	public void initAndValidate() {
@@ -130,16 +142,18 @@ public class MATreeLikelihood extends TreeLikelihood {
                 cachedStates[i] = code; // Causes ambiguous states to be ignored.
         }
         likelihoodCore.setNodeStates(nodeNr, cachedStates);
+        tempTipNodes.add(nodeNr);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
 
 	/*
-	 * returns pattern log likelihoods after setting sequence for node with given nodeNr 
+	 * returns pattern log likelihoods after setting sequence for node with given nodeNr
 	 * to states encoded in sites
 	 */
 	public double [] getLogProbsForPartialsSequence(int nodeNr, double [] tipLikelihoods) {
         likelihoodCore.setNodePartials(nodeNr, tipLikelihoods);
+        tempTipNodes.add(nodeNr);
 
         return calcPatternLogLikelihoods(nodeNr);
 	}
@@ -153,7 +167,13 @@ public class MATreeLikelihood extends TreeLikelihood {
         Node node = treeInput.get().getNode(nodeNr);
         do {
         	node = node.getParent();
-            likelihoodCore.calculatePartials(node.getLeft().getNr(), node.getRight().getNr(), node.getNr());
+        	final int parentNr = node.getNr();
+        	// Flip to scratch buffer so we don't overwrite partials captured by store().
+        	// Flip at most once per node per proposal (toggling twice would clobber the stored slot).
+        	if (flippedNodes.add(parentNr)) {
+        		likelihoodCore.setNodePartialsForUpdate(parentNr);
+        	}
+            likelihoodCore.calculatePartials(node.getLeft().getNr(), node.getRight().getNr(), parentNr);
         } while (!node.isRoot());
         
         // do fiddly bits at the root
@@ -182,21 +202,36 @@ public class MATreeLikelihood extends TreeLikelihood {
 	@Override
 	public void store() {
     	dirtySequences.clear();
+    	tempTipNodes.clear();
+    	flippedNodes.clear();
 
     	super.store();
 	}
-	
+
 	@Override
 	public void restore() {
 		super.restore();
-		
+
+    	// Resync every tip we temporarily mutated (via getLogProbs*Sequence) from
+    	// the alignment, which has itself just been rolled back. This is a superset
+    	// of alignment.getDirtySequenceIndices() because getLogProbs* may probe tips
+    	// that weren't alignment-dirty (e.g. the partials-fixup leaf).
+    	dirtySequences.clear();
+    	dirtySequences.addAll(tempTipNodes);
+    	for (Integer i : alignment.getDirtySequenceIndices()) {
+    		dirtySequences.add(i);
+    	}
     	updateTipData();
     	dirtySequences.clear();
+    	tempTipNodes.clear();
+    	flippedNodes.clear();
 	}
-	
+
 	@Override
 	protected void accept() {
     	dirtySequences.clear();
+    	tempTipNodes.clear();
+    	flippedNodes.clear();
 		alignment.accept();
 		super.accept();
 	}

--- a/src/mutablealignment/MATreeLikelihood.java
+++ b/src/mutablealignment/MATreeLikelihood.java
@@ -246,15 +246,14 @@ public class MATreeLikelihood extends TreeLikelihood {
 	public void restore() {
 		super.restore();
 
-    	// Resync every tip we temporarily mutated (via getLogProbs*Sequence) from
-    	// the alignment, which has itself just been rolled back. This is a superset
-    	// of alignment.getDirtySequenceIndices() because getLogProbs* may probe tips
-    	// that weren't alignment-dirty (e.g. the partials-fixup leaf).
-    	dirtySequences.clear();
+    	// Resync every tip we temporarily mutated from the (now-rolled-back)
+    	// alignment. dirtySequences was populated during the previous
+    	// calculateLogP from alignment.getDirtySequenceIndices(); we can't
+    	// re-query that here because alignment.restore() has already cleared
+    	// the edit list. Add probe-touched tips (tempTipNodes) since they may
+    	// not have been alignment-dirty (e.g. ExchangeGibbsOperator's partials-
+    	// fixup leaf).
     	dirtySequences.addAll(tempTipNodes);
-    	for (Integer i : alignment.getDirtySequenceIndices()) {
-    		dirtySequences.add(i);
-    	}
     	updateTipData();
     	dirtySequences.clear();
     	tempTipNodes.clear();


### PR DESCRIPTION
Fixes store and restore in BeagleMATreeLikelihood.java to work properly with Gibbs operator in phylonco.